### PR TITLE
Issue 2589 - Encoding issue with "required URL field" for video transcripts 

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -225,7 +225,7 @@
                                 // If a transcript URL was provided, output a link for it.
                                 if (transcriptUrl) {
                                     var linkElem = jQuery('<a>', {
-                                        text: Drupal.t('Transcript for \'@title\' video', { '@title': title }),
+                                        text: Drupal.t('Transcript for \'!title\' video', { '!title': title }),
                                         href: transcriptUrl,
                                     });
                                     widget.element.appendHtml(linkElem[0].outerHTML);


### PR DESCRIPTION
See https://github.com/CityofOttawa/ottawa_profile/issues/2589

The cause of this because t function sanitizing it; since we didn't do anything with the title before displaying as is should be fine.